### PR TITLE
Add dockerfile for 3.8 (pre-release)

### DIFF
--- a/Dockerfile.3.8
+++ b/Dockerfile.3.8
@@ -1,0 +1,8 @@
+FROM python:3.8-rc
+
+RUN pip install poetry
+
+# download test reporter as a static binary
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 \
+    >/bin/cc-test-reporter \
+    && chmod +x /bin/cc-test-reporter


### PR DESCRIPTION
Although a decision on when we want to start supporting python 3.8 hasn't been made yet, I think we might as well get the CI for it set up so we can start catching any potential issues.

When Python 3.8 is formally released (towards the end of this year) we should change this to use the `python:3.8` upstream image instead of `python:3.8-rc`.